### PR TITLE
fix(deck): 新帳號綁定後可正常選牌，UX 更直覺

### DIFF
--- a/src/components/CardSelectionComponent.tsx
+++ b/src/components/CardSelectionComponent.tsx
@@ -51,7 +51,7 @@ const CardSelectionComponent: React.FC<CardSelectionComponentProps> = ({
               onClick={() => {
                 if (!isInDeck && (useSelected ? selectedCards.length < 10 || isSelected : true)) {
                   if (!useSelected) {
-                    setSelectedCards(currentDeck.length ? [...currentDeck] : []);
+                    setSelectedCards([gem.id]);
                   } else {
                     toggleCardSelection(gem.id);
                   }


### PR DESCRIPTION
- 新帳號綁定後，第一次點擊卡片可直接開始選牌，不會自動複製現有 deck。
- UX 更直覺，完全由使用者決定要選哪幾張卡。
- 修正 CardSelectionComponent.tsx。